### PR TITLE
feat: add native and non native balances information

### DIFF
--- a/src/accounts/accounts.service.ts
+++ b/src/accounts/accounts.service.ts
@@ -38,6 +38,8 @@ export class AccountsService {
       earnedValue: 0,
       balances: [],
       claimableBalances,
+      nativeBalance: boostData.nativeBalance,
+      nonNativeBalance: boostData.nonNativeBalance,
     };
 
     if (user) {

--- a/src/accounts/interfaces/account.interface.ts
+++ b/src/accounts/interfaces/account.interface.ts
@@ -11,4 +11,6 @@ export interface Account {
   earnedValue: number;
   balances: SettBalance[];
   claimableBalances: CachedBalance[];
+  nativeBalance: number;
+  nonNativeBalance: number;
 }

--- a/src/leaderboards/interface/cached-boost.interface.ts
+++ b/src/leaderboards/interface/cached-boost.interface.ts
@@ -20,4 +20,10 @@ export class CachedBoost {
 
   @attribute()
   nftMultiplier!: number;
+
+  @attribute()
+  nativeBalance!: number;
+
+  @attribute()
+  nonNativeBalance!: number;
 }

--- a/src/leaderboards/leaderboards.service.ts
+++ b/src/leaderboards/leaderboards.service.ts
@@ -48,12 +48,14 @@ export class LeaderBoardsService {
     const boostData: BoostData = JSON.parse(boostFile.toString('utf-8'));
     const boosts: UserBoost[] = Object.entries(boostData.userData).map((entry) => {
       const [address, userBoost] = entry;
-      const { boost, stakeRatio, nftMultiplier } = userBoost;
+      const { boost, stakeRatio, nftMultiplier, nativeBalance, nonNativeBalance } = userBoost;
       return {
         address: ethers.utils.getAddress(address),
         boost,
         stakeRatio,
         nftMultiplier,
+        nativeBalance: nativeBalance || 0,
+        nonNativeBalance: nonNativeBalance || 0,
       };
     });
     return boosts

--- a/src/rewards/interfaces/boost.interface.ts
+++ b/src/rewards/interfaces/boost.interface.ts
@@ -5,4 +5,6 @@ export interface Boost {
   stakeRatio: number;
   nftMultiplier: number;
   multipliers: BoostMultipliers;
+  nativeBalance: number;
+  nonNativeBalance: number;
 }

--- a/src/rewards/rewards.service.ts
+++ b/src/rewards/rewards.service.ts
@@ -100,6 +100,8 @@ export class RewardsService {
         stakeRatio: 0,
         nftMultiplier: 1,
         multipliers: defaultMultipliers,
+        nativeBalance: 0,
+        nonNativeBalance: 0,
       };
     }
     const userMulipliers = boostData.multipliers;


### PR DESCRIPTION
Native and non native balance information is required in the UI and is already available in the boost file.