### PR TITLE
fix: correct filter check

### DIFF
--- a/src/indexers/boosts-indexer.ts
+++ b/src/indexers/boosts-indexer.ts
@@ -50,8 +50,9 @@ export async function updateChainBoosts(chain: Chain): Promise<void> {
     // update the stored account multipliers, removing old chain multipliers
     for (const account of cachedAccounts) {
       const userChainMultipliers = boostMultipliers[account.address];
-      account.multipliers = account.multipliers.filter((m) => m.network === chain.network).concat(userChainMultipliers);
+      account.multipliers = account.multipliers.filter((m) => m.network !== chain.network).concat(userChainMultipliers);
     }
+
     for await (const _saved of mapper.batchPut(cachedAccounts));
   } catch (err) {
     console.error(err);


### PR DESCRIPTION
The check on the comment as you can read the filter should include entries which do NOT match - to exclude the entries being added by the current chain. This causes the list of multipliers to grow infinitely. 

closes #750  