### PR TITLE
fix: remove test code linkage

### DIFF
--- a/src/tokens/mocks/full-token.mock.ts
+++ b/src/tokens/mocks/full-token.mock.ts
@@ -4,7 +4,6 @@ import { TokenFullMap } from '../interfaces/token-full.interface';
 import { TOKENS } from '../../config/tokens.config';
 import { PricingType } from '../../prices/enums/pricing-type.enum';
 import { getRemDiggPrice } from '../../prices/custom/remdigg-price';
-import { TEST_ADDR } from '../../test/tests.utils';
 
 // temp solution, remove after sdk lib mocks
 export const fullTokenMockMap: TokenFullMap = {
@@ -158,12 +157,5 @@ export const fullTokenMockMap: TokenFullMap = {
     name: 'Sushiswap: WBTC-ETH',
     symbol: 'SLP-WBTC-ETH',
     type: PricingType.Vault,
-  },
-  [TEST_ADDR]: {
-    address: TEST_ADDR,
-    symbol: 'TEST',
-    name: 'TEST',
-    decimals: 18,
-    type: PricingType.Contract,
   },
 };


### PR DESCRIPTION
# Summary

Token mock configuration contained a reference to test code and was used in the model code. This is one way to fix the issue.

```
2022-03-20T01:05:56.630Z	undefined	ERROR	Uncaught Exception 	
{
    "errorType": "Runtime.ImportModuleError",
    "errorMessage": "Error: Cannot find module 'jest-create-mock-instance'\nRequire stack:\n- /var/task/src/test/tests.utils.js\n- /var/task/src/tokens/mocks/full-token.mock.js\n- /var/task/src/accounts/interfaces/account-model.interface.js\n- /var/task/src/accounts/accounts.controller.js\n- /var/task/src/ControllerRegistry.js\n- /var/task/src/Server.js\n- /var/task/src/LambdaServer.js\n- /var/runtime/UserFunction.js\n- /var/runtime/index.js",
    "stack": [
        "Runtime.ImportModuleError: Error: Cannot find module 'jest-create-mock-instance'",
```