### PR TITLE
fix: filter only compound sources

### DIFF
--- a/src/rewards/enums/source-type.enum.ts
+++ b/src/rewards/enums/source-type.enum.ts
@@ -3,5 +3,5 @@ export enum SourceType {
   TradeFee = 'lp_fee',
   PreCompound = 'precompound',
   Compound = 'compound',
-  Native = 'native',
+  Flywheel = 'flywheel',
 }

--- a/src/vaults/__snapshots__/vaults.utils.spec.ts.snap
+++ b/src/vaults/__snapshots__/vaults.utils.spec.ts.snap
@@ -328,13 +328,13 @@ Array [
   },
   CachedValueSource {
     "address": "0x19D97D8fA813EE2f51aD4B4e04EA08bAf4DFfC28",
-    "addressValueSourceType": "0x19D97D8fA813EE2f51aD4B4e04EA08bAf4DFfC28_derivative_vault_flywheel",
+    "addressValueSourceType": "0x19D97D8fA813EE2f51aD4B4e04EA08bAf4DFfC28_flywheel",
     "apr": 0.0000013944295327135587,
     "boostable": false,
     "maxApr": 0.0000013944295327135587,
     "minApr": 0.0000013944295327135587,
     "name": "Vault Flywheel",
-    "type": "derivative_vault_flywheel",
+    "type": "flywheel",
   },
   CachedValueSource {
     "address": "0x19D97D8fA813EE2f51aD4B4e04EA08bAf4DFfC28",

--- a/src/vaults/vaults.service.ts
+++ b/src/vaults/vaults.service.ts
@@ -147,9 +147,8 @@ export class VaultsService {
     vault.lastHarvest = pendingHarvest.lastHarvestedAt;
 
     const harvestProjection = this.getVaultYieldProjection(vault, pendingHarvest);
-    const passiveSources = sourcesApy.filter(
-      (s) => s.type.includes(SourceType.TradeFee) || s.type.includes(SourceType.Emission),
-    );
+    // filter out all vault compound sources - this include 'precompound' as well
+    const passiveSources = sourcesApy.filter((s) => !s.type.includes(SourceType.Compound));
     const passiveSourcesApr = passiveSources.reduce((total, s) => (total += s.apr), 0);
     const convertedPassiveSources = passiveSources.map((s) => {
       const { name, apr, address, type } = s;

--- a/src/vaults/vaults.utils.spec.ts
+++ b/src/vaults/vaults.utils.spec.ts
@@ -1,6 +1,5 @@
 import BadgerSDK, {
   BadgerGraph,
-  ONE_YEAR_MS,
   Protocol,
   TokensService,
   VaultBehavior,
@@ -47,7 +46,6 @@ import {
   getVaultHarvestsOnChain,
   getVaultPerformance,
   getVaultTokenPrice,
-  getVaultUnderlyingPerformance,
   VAULT_SOURCE,
 } from './vaults.utils';
 
@@ -419,27 +417,6 @@ describe('vaults.utils', () => {
         expect(estimateDerivativeEmission(compound, emission, compoundEmission)).toEqual(expected);
       },
     );
-  });
-
-  describe('getVaultUnderlyingPerformance', () => {
-    it('returns 0 for no pricePerFullShare increase', async () => {
-      const snapshot = randomSnapshot(MOCK_VAULT_DEFINITION);
-      setupMapper([snapshot]);
-      setFullTokenDataMock();
-      const result = await getVaultUnderlyingPerformance(TEST_CHAIN, MOCK_VAULT_DEFINITION);
-      result.forEach((r) => expect(r.apr).toEqual(0));
-    });
-
-    it('returns expected apr for increase in pricePerFullShare', async () => {
-      const snapshots = randomSnapshots(MOCK_VAULT_DEFINITION);
-      setupMapper(snapshots);
-      const duration = snapshots[0].timestamp - snapshots[snapshots.length - 1].timestamp;
-      const deltaPpfs = snapshots[0].pricePerFullShare - snapshots[snapshots.length - 1].pricePerFullShare;
-      const expected = (deltaPpfs / snapshots[snapshots.length - 1].pricePerFullShare) * (ONE_YEAR_MS / duration) * 100;
-      setFullTokenDataMock();
-      const result = await getVaultUnderlyingPerformance(TEST_CHAIN, MOCK_VAULT_DEFINITION);
-      result.forEach((r) => expect(r.apr).toEqual(expected));
-    });
   });
 
   describe('getVaultHarvestsOnChain', () => {


### PR DESCRIPTION
# Summary

- update filter to allow only elements that are NOT compounding (allows for flywheel vs. older implementation)
- remove ancient ppfs measuring methods - we should NEVER! use these, and prefer our harvest / distribution events to this