### PR TITLE
fix: update compound apr input values

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -68,7 +68,7 @@ package:
 
 provider:
   name: aws
-  runtime: nodejs16.x
+  runtime: nodejs14.x
   memorySize: 2048
   stage: staging
   region: us-west-1

--- a/src/vaults/interfaces/harvest-report.interface.ts
+++ b/src/vaults/interfaces/harvest-report.interface.ts
@@ -1,0 +1,10 @@
+import { HarvestType } from '@badger-dao/sdk';
+
+export interface HarvestReport {
+  date: string;
+  type: HarvestType;
+  amount: string;
+  value: string;
+  balance: string;
+  apr: string;
+}


### PR DESCRIPTION
# Summary

- fix input value to yield calculation function

this summary, and outputs should roughly match 1:1 the apr generated by breaking down the values vs. the whole apr. 
the compound yield was being measured against the TOTAL value of tokens - this should be the average value of the principal in $, vs. the yield of that token in $ for the harvest

this moves the values back in line net with the estimations provided in the logs on a run

example:

```
cvxCRV Harvest Report
┌─────────┬───────────────────┬───────────┬──────────┬────────────────────┬────────────┬──────────────┬─────────┐
│ (index) │       date        │  amount   │  token   │        type        │   value    │   balance    │   apr   │
├─────────┼───────────────────┼───────────┼──────────┼────────────────────┼────────────┼──────────────┼─────────┤
│    0    │ 'Thu Aug 18 2022' │ '5912.79' │ 'cvxCRV' │     'Harvest'      │ '$8455.28' │ '2721669.61' │ '3.52%' │
│    1    │ 'Thu Aug 18 2022' │ '254.85'  │ 'bveCVX' │ 'TreeDistribution' │ '$1975.07' │ '2721669.61' │ '0.82%' │
│    2    │ 'Sun Aug 14 2022' │ '6201.34' │ 'cvxCRV' │     'Harvest'      │ '$8867.91' │ '2774912.68' │ '3.62%' │
│    3    │ 'Sun Aug 14 2022' │ '261.25'  │ 'bveCVX' │ 'TreeDistribution' │ '$2024.71' │ '2774912.68' │ '0.83%' │
│    4    │ 'Wed Aug 10 2022' │ '6873.45' │ 'cvxCRV' │     'Harvest'      │ '$9829.04' │ '2760146.64' │ '4.03%' │
│    5    │ 'Wed Aug 10 2022' │ '270.44'  │ 'bveCVX' │ 'TreeDistribution' │ '$2095.92' │ '2760146.64' │ '0.86%' │
│    6    │ 'Sat Aug 06 2022' │ '6541.92' │ 'cvxCRV' │     'Harvest'      │ '$9354.95' │ '2757584.79' │ '3.84%' │
│    7    │ 'Sat Aug 06 2022' │ '278.41'  │ 'bveCVX' │ 'TreeDistribution' │ '$2157.65' │ '2757584.79' │ '0.89%' │
└─────────┴───────────────────┴───────────┴──────────┴────────────────────┴────────────┴──────────────┴─────────┘
Vault Holdings: $5915727 (2753578 tokens), Total Earned: $44760.53, Est. Yield: 18.41%
```