### PR TITLE
chore: fix liquidity for bveoxd + convex

### DIFF
--- a/src/protocols/strategies/convex.strategy.ts
+++ b/src/protocols/strategies/convex.strategy.ts
@@ -99,8 +99,8 @@ async function getLiquiditySources(chain: Chain, vaultDefinition: VaultDefinitio
   const lpSources = bveCVXSources.map((s) => {
     const { apr, minApr, maxApr, name, type } = s;
     const scaledApr = apr * scalar;
-    const min = minApr / apr;
-    const max = maxApr / apr;
+    const min = apr > 0 ? minApr / apr : 0;
+    const max = apr > 0 ? maxApr / apr : 0;
     return createYieldSource(vaultDefinition, type, name, scaledApr, { min, max });
   });
   const cachedTradeFees = await getCurvePerformance(chain, vaultDefinition);

--- a/src/protocols/strategies/oxdao.strategy.ts
+++ b/src/protocols/strategies/oxdao.strategy.ts
@@ -2,9 +2,9 @@ import { VaultDefinitionModel } from '../../aws/models/vault-definition.model';
 import { YieldSource } from '../../aws/models/yield-source.model';
 import { Chain } from '../../chains/config/chain.config';
 import { TOKENS } from '../../config/tokens.config';
-import { SourceType } from '../../rewards/enums/source-type.enum';
-import { getFullToken, getVaultTokens } from '../../tokens/tokens.utils';
+import { getVaultTokens } from '../../tokens/tokens.utils';
 import { getCachedVault, queryYieldSources } from '../../vaults/vaults.utils';
+import { createYieldSource } from '../../vaults/yields.utils';
 
 export class OxDaoStrategy {
   static async getValueSources(chain: Chain, vaultDefinition: VaultDefinitionModel): Promise<YieldSource[]> {
@@ -19,9 +19,8 @@ export class OxDaoStrategy {
 
 async function getLiquiditySources(chain: Chain, vaultDefinition: VaultDefinitionModel): Promise<YieldSource[]> {
   const bveOXDVault = await chain.vaults.getVault(TOKENS.BVEOXD);
-  const [bveOXDLP, bveOXD, bveOXDSources] = await Promise.all([
+  const [bveOXDLP, bveOXDSources] = await Promise.all([
     getCachedVault(chain, vaultDefinition),
-    getCachedVault(chain, bveOXDVault),
     queryYieldSources(bveOXDVault),
   ]);
   const vaultTokens = await getVaultTokens(chain, bveOXDLP);
@@ -30,19 +29,11 @@ async function getLiquiditySources(chain: Chain, vaultDefinition: VaultDefinitio
     .map((t) => t.value)
     .reduce((total, val) => (total += val), 0);
   const scalar = bveOXDValue / bveOXDLP.value;
-  const vaultToken = await getFullToken(chain, bveOXD.vaultToken);
   return bveOXDSources.map((s) => {
-    if (s.type === SourceType.Compound || s.type === SourceType.PreCompound) {
-      s.name = `${vaultToken.name} ${s.name}`;
-      const sourceTypeName = `${s.type === SourceType.Compound ? 'Derivative ' : ''}${vaultToken.name} ${s.type}`;
-      s.id = s.id.replace(s.type, sourceTypeName.replace(/ /g, '_').toLowerCase());
-    }
-    // rewrite object keys to simulate sources from the lp vault
-    s.id = s.id.replace(bveOXD.vaultToken, bveOXDLP.vaultToken);
-    s.address = bveOXDLP.vaultToken;
-    s.apr *= scalar;
-    s.maxApr *= scalar;
-    s.minApr *= scalar;
-    return s;
+    const { apr, minApr, maxApr, name, type } = s;
+    const scaledApr = apr * scalar;
+    const min = apr > 0 ? minApr / apr : 0;
+    const max = apr > 0 ? maxApr / apr : 0;
+    return createYieldSource(vaultDefinition, type, name, scaledApr, { min, max });
   });
 }

--- a/src/vaults/interfaces/harvest-report.interface.ts
+++ b/src/vaults/interfaces/harvest-report.interface.ts
@@ -4,6 +4,7 @@ export interface HarvestReport {
   date: string;
   type: HarvestType;
   amount: string;
+  token: string;
   value: string;
   balance: string;
   apr: string;

--- a/src/vaults/yields.utils.ts
+++ b/src/vaults/yields.utils.ts
@@ -521,6 +521,7 @@ export async function estimateVaultPerformance(
     const report: HarvestReport = {
       date: new Date(event.timestamp * 1000).toDateString(),
       amount: amount.toFixed(2),
+      token: token.symbol,
       type: event.type,
       value: `$${tokenEarned.toFixed(2)}`,
       balance: balance.toFixed(2),


### PR DESCRIPTION
# Summary

- fixes `NaN` readings in apr for non compounding vaults