### PR TITLE
fix: NaN value at createdAt field for old registry vaults

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -35,8 +35,8 @@
         "vars": "all",
         "varsIgnorePattern": "^_",
         "args": "after-used",
-        "argsIgnorePattern": "^_",
-      },
-    ],
+        "argsIgnorePattern": "^_"
+      }
+    ]
   }
 }

--- a/src/indexers/__snapshots__/indexer.utils.spec.ts.snap
+++ b/src/indexers/__snapshots__/indexer.utils.spec.ts.snap
@@ -7,7 +7,7 @@ VaultDefinitionModel {
   "bouncer": "none",
   "chain": "ethereum",
   "client": "",
-  "createdAt": NaN,
+  "createdAt": null,
   "depositToken": "0x075b1bb99792c9E1041bA13afEf80C91a1e70fB3",
   "id": "ethereum-0xd04c48A53c111300aD41190D63681ed3dAd998eC",
   "isNew": false,

--- a/src/indexers/indexer.utils.ts
+++ b/src/indexers/indexer.utils.ts
@@ -83,7 +83,8 @@ export async function constructVaultDefinition(
   return Object.assign(new VaultDefinitionModel(), {
     id: getVaultEntityId(chain, vault),
     address,
-    createdAt: Number(createdAt),
+    // can be null for old from registryV1, legacy issue
+    createdAt: !!createdAt ? Number(createdAt) : null,
     chain: chain.network,
     isProduction: 1,
     version: vault.version as VaultVersion,


### PR DESCRIPTION
In order to save history for old registry vault, there is backward compatibility with all old onchain events, thus even added to registryV2 wont cr8 entity in the graph for them, but only extend, the following logic applies to all versions of vaults, u can find it at lines below
https://github.com/Badger-Finance/badger-subgraph/blob/master/src/vaults/src/entities/badger-sett.ts#L21