### PR TITLE
fix: update vault event indexing logic

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -514,12 +514,12 @@ functions:
 
   index-vault-yield-events:
     handler: src/indexers/vault-harvests-indexer.updateVaultHarvests
-    timeout: 360
+    timeout: 600
     events:
       - schedule:
           name: ${self:service}-${self:custom.stage}-index-vault-harvests
           description: 'index onchain harvests for all vaults'
-          rate: rate(10 minutes)
+          rate: rate(11 minutes)
 
   index-leaderboard:
     handler: src/indexers/leaderboard-indexer.indexBoostLeaderBoard

--- a/serverless_frontend.yml
+++ b/serverless_frontend.yml
@@ -512,12 +512,12 @@ functions:
 
   index-vault-yield-events:
     handler: src/indexers/vault-harvests-indexer.updateVaultHarvests
-    timeout: 360
+    timeout: 600
     events:
       - schedule:
           name: ${self:service}-${self:custom.stage}-index-vault-harvests
           description: 'index onchain harvests for all vaults'
-          rate: rate(10 minutes)
+          rate: rate(11 minutes)
 
   index-leaderboard:
     handler: src/indexers/leaderboard-indexer.indexBoostLeaderBoard

--- a/src/indexers/vault-harvests-indexer.ts
+++ b/src/indexers/vault-harvests-indexer.ts
@@ -1,19 +1,45 @@
 import { getDataMapper, getVaultEntityId } from '../aws/dynamodb.utils';
 import { VaultYieldEvent } from '../aws/models/vault-yield-event.model';
 import { getSupportedChains } from '../chains/chains.utils';
-import { loadYieldEvents, queryLastHarvestBlock } from '../vaults/harvests.utils';
+import { HARVEST_SCAN_BLOCK_INCREMENT, loadYieldEvents, queryLastHarvestBlock } from '../vaults/harvests.utils';
+import { YieldEvent } from '../vaults/interfaces/yield-event';
 
 export async function updateVaultHarvests() {
   const chains = getSupportedChains();
   const mapper = getDataMapper();
 
   for (const chain of chains) {
+    const sdk = await chain.getSdk();
+    const currentBlock = await sdk.provider.getBlockNumber();
     const vaults = await chain.vaults.all();
 
     for (const vault of vaults) {
       try {
-        const lastHarvestBlock = await queryLastHarvestBlock(chain, vault);
-        const yieldEvents = await loadYieldEvents(chain, vault, lastHarvestBlock);
+        let lastHarvestBlock = await queryLastHarvestBlock(chain, vault);
+        let yieldEvents: YieldEvent[] = [];
+
+        console.log(`[${vault.name}]: Last Indexed Block ${lastHarvestBlock}`);
+        while (true) {
+          yieldEvents = await loadYieldEvents(chain, vault, lastHarvestBlock);
+          console.log(`[${vault.name}]: Discovered ${yieldEvents.length} yield events`);
+
+          // found some events, let's check them out
+          if (yieldEvents.length > 0) {
+            break;
+          } else {
+            lastHarvestBlock += HARVEST_SCAN_BLOCK_INCREMENT;
+            console.log(
+              `[${vault.name}]: Increment block scan to ${lastHarvestBlock} - ${
+                lastHarvestBlock + HARVEST_SCAN_BLOCK_INCREMENT
+              }`,
+            );
+          }
+
+          // we are checking blocks that do not exist yet, and found no sources - we are up to date!
+          if (lastHarvestBlock >= currentBlock) {
+            break;
+          }
+        }
 
         if (yieldEvents.length === 0) {
           console.log(`${vault.name} is up to date.`);

--- a/src/vaults/harvests.utils.spec.ts
+++ b/src/vaults/harvests.utils.spec.ts
@@ -1,4 +1,4 @@
-import { Vault, Vault__factory,VaultsService } from '@badger-dao/sdk';
+import { Vault, Vault__factory, VaultsService } from '@badger-dao/sdk';
 import { BigNumber } from 'ethers';
 
 import { Chain } from '../chains/config/chain.config';
@@ -18,6 +18,7 @@ import * as tokensUtils from '../tokens/tokens.utils';
 import * as influenceUtils from '../vaults/influence.utils';
 import * as vaultsUtils from '../vaults/vaults.utils';
 import {
+  HARVEST_SCAN_START_BLOCK,
   loadYieldEvents,
   queryLastHarvestBlock,
   queryVaultHistoricYieldEvents,
@@ -278,7 +279,7 @@ describe('harvests.utils', () => {
       it('returns 0', async () => {
         mockQuery([]);
         const result = await queryLastHarvestBlock(chain, MOCK_VAULT_DEFINITION);
-        expect(result).toEqual(0);
+        expect(result).toEqual(HARVEST_SCAN_START_BLOCK);
       });
     });
     describe('previously stored harvest data', () => {


### PR DESCRIPTION
# Summary

- fixes an issue where 0 is always returned for the start block (even if indexed events exist)
- fixes an issue where vaults are considered up to date because no events were located (in time or otherwise) for a given block range