### PR TITLE
refactor: tune harvests indexer

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -515,12 +515,12 @@ functions:
 
   index-vault-yield-events:
     handler: src/indexers/vault-harvests-indexer.updateVaultHarvests
-    timeout: 900
+    timeout: 360
     events:
       - schedule:
           name: ${self:service}-${self:custom.stage}-index-vault-harvests
           description: 'index onchain harvests for all vaults'
-          rate: rate(20 minutes)
+          rate: rate(8 minutes)
 
   index-leaderboard:
     handler: src/indexers/leaderboard-indexer.indexBoostLeaderBoard


### PR DESCRIPTION
# Summary

- runs taking ~260k-280k ms 
- sets run time to timeout after 360k ms
- run schedule set to 540k ms

we can revisit this as needed, the longer run times are probably good as we increase vaults 
might want to consider minor alterations to the code to parallelize rpc requests a bit to trim down runtimes
additionally, longer run times support long period indexing for our oldest vaults (up to 2 years) and need to stay long for now