### PR TITLE
fix: flaky apr field in ddb mapper

### DIFF
--- a/src/aws/models/cached-token-rate.interface.ts
+++ b/src/aws/models/cached-token-rate.interface.ts
@@ -1,9 +1,25 @@
 import { attribute } from '@aws/dynamodb-data-mapper-annotations';
 import { TokenRate } from '@badger-dao/sdk';
 
-import { CachedTokenBalance } from './cached-token-balance.interface';
+export class CachedTokenRate implements TokenRate {
+  @attribute()
+  address!: string;
 
-export class CachedTokenRate extends CachedTokenBalance implements TokenRate {
+  @attribute()
+  name!: string;
+
+  @attribute()
+  symbol!: string;
+
+  @attribute()
+  decimals!: number;
+
+  @attribute()
+  balance!: number;
+
+  @attribute()
+  value!: number;
+
   @attribute()
   apr!: number;
 }


### PR DESCRIPTION
sometimes ddb put wrong symbol to fetch scheme proto from embed class to unpack it correctly, my guess, its connected with hot/cold starts of lambda, thats why field `apr` in `CachedTokenRate` doesnt appear in response. Currently can be reproduced on stg.

made structure flat, so there should be only 1 link now

https://staging-api.badger.com/v3/vaults?address=0x371B7C451858bd88eAf392B383Df8bd7B8955d5a
![image](https://user-images.githubusercontent.com/18405840/192006239-822b9893-2490-4fa1-857d-6d32951e6433.png)
